### PR TITLE
deps: updates wazero to 1.0.0-pre.3

### DIFF
--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/http-wasm/http-wasm-guest-tinygo v0.0.0
-	github.com/http-wasm/http-wasm-host-go v0.0.0-20221027011750-9cecd035cb81
+	github.com/http-wasm/http-wasm-host-go v0.0.0-20221028140305-44c7591dd1e4
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221003082636-0b4dbfd8d6ca
+	github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028040104-7013eeb9b76b
 )
 
 require (

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/http-wasm/http-wasm-host-go v0.0.0-20221027011750-9cecd035cb81 h1:hG1HDYzTUZl7uacRY++FGKnGJf6IRs2ESznmK2Rv9+E=
-github.com/http-wasm/http-wasm-host-go v0.0.0-20221027011750-9cecd035cb81/go.mod h1:ZtxjVzVCo7NY3lKL+6r6/fCWwBc5lkfCEikYVGwBKlo=
+github.com/http-wasm/http-wasm-host-go v0.0.0-20221028140305-44c7591dd1e4 h1:9sU8abxj44DJFUpUw1P7gJFWyb/f4hHQX6wY9DKBdGM=
+github.com/http-wasm/http-wasm-host-go v0.0.0-20221028140305-44c7591dd1e4/go.mod h1:Sj9ZVvFhtBY52SAmHmV3DT9aRER6EVUoBKPebHz0p1Q=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -10,8 +10,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221003082636-0b4dbfd8d6ca h1:KXz2bwfTTqR6TYvz2vjoEO3tFbkok+6wTlmY6FFZm5E=
-github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221003082636-0b4dbfd8d6ca/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028040104-7013eeb9b76b h1:xge4THjeJbuZlc+NvC6CzgdQqD29mntJLMM3uDp6eZk=
+github.com/tetratelabs/wazero v1.0.0-pre.2.0.20221028040104-7013eeb9b76b/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.3](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.3).

Notably, this improves performance and changes host function syntax.