### PR TITLE
deps: updates wazero 1.0.0-pre.8

### DIFF
--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -186,20 +186,20 @@ func testConsole(t *testing.T, content []byte, logMessages []string, stdout, std
 	require.Equal(t, `{"hello": "world"}`, string(content))
 	require.Empty(t, stderr)
 	require.Equal(t, `POST /v1.0/hi?name=panda HTTP/1.1
-Accept-Encoding: gzip
-Content-Length: 18
-Content-Type: application/json
-Host: localhost
-User-Agent: Go-http-client/1.1
+accept-encoding: gzip
+content-length: 18
+content-type: application/json
+host: localhost
+user-agent: Go-http-client/1.1
 
 {"hello": "panda"}
 
 HTTP/1.1 200
-Content-Type: application/json
-Set-Cookie: a=b
-Set-Cookie: c=d
-Trailer: grpc-status
-Transfer-Encoding: chunked
+content-type: application/json
+set-cookie: a=b
+set-cookie: c=d
+trailer: grpc-status
+transfer-encoding: chunked
 
 {"hello": "world"}
 grpc-status: 1

--- a/internal/e2e/go.mod
+++ b/internal/e2e/go.mod
@@ -4,9 +4,9 @@ go 1.18
 
 require (
 	github.com/http-wasm/http-wasm-guest-tinygo v0.0.0
-	github.com/http-wasm/http-wasm-host-go v0.1.0
+	github.com/http-wasm/http-wasm-host-go v0.3.2
 	github.com/stretchr/testify v1.8.0
-	github.com/tetratelabs/wazero v1.0.0-pre.3
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 )
 
 require (

--- a/internal/e2e/go.sum
+++ b/internal/e2e/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/http-wasm/http-wasm-host-go v0.1.0 h1:UAFh62U/9s6jyK0SFj1BfuKX9A1uYMKTipuy7CkJpf4=
-github.com/http-wasm/http-wasm-host-go v0.1.0/go.mod h1:wzJRRVIN1Xzdlb/aXbShe9MiOO0BKA9jFVH7lSqKFTs=
+github.com/http-wasm/http-wasm-host-go v0.3.2 h1:iOStbkL8rUKSSwNl/+vt4pUiQrwCrEFoRTSfEU4D/v8=
+github.com/http-wasm/http-wasm-host-go v0.3.2/go.mod h1:GSIkcGfuhxYJdowxvsnsoIKH7SzoMqUEmbog8o9NkhA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -10,8 +10,8 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tetratelabs/wazero v1.0.0-pre.3 h1:Z5fbogMUGcERzaQb9mQU8+yJSy0bVvv2ce3dfR4wcZg=
-github.com/tetratelabs/wazero v1.0.0-pre.3/go.mod h1:M8UDNECGm/HVjOfq0EOe4QfCY9Les1eq54IChMLETbc=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) 
