### PR TITLE
Add SourceAddr support

### DIFF
--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -121,8 +121,8 @@ type Request interface {
 	// Headers allows access to any incoming request headers.
 	Headers() Header
 
-	// GetRemoteAddr returns client RemoteAddr.
-	GetRemoteAddr() string
+	// GetSourceAddr returns client SourceAddr.
+	GetSourceAddr() string
 
 	// Body allows access to any incoming request body. To read this without
 	// preventing the Next from reading it, enable FeatureBufferRequest.

--- a/handler/api/api.go
+++ b/handler/api/api.go
@@ -121,6 +121,9 @@ type Request interface {
 	// Headers allows access to any incoming request headers.
 	Headers() Header
 
+	// GetRemoteAddr returns client RemoteAddr.
+	GetRemoteAddr() string
+
 	// Body allows access to any incoming request body. To read this without
 	// preventing the Next from reading it, enable FeatureBufferRequest.
 	Body() Body

--- a/handler/internal/imports/host.go
+++ b/handler/internal/imports/host.go
@@ -178,3 +178,7 @@ func GetStatusCode() uint32 {
 func SetStatusCode(statusCode uint32) {
 	setStatusCode(statusCode)
 }
+
+func GetRemoteAddr(ptr uint32, limit BufLimit) (len uint32) {
+	return getRemoteAddr(ptr, limit)
+}

--- a/handler/internal/imports/host.go
+++ b/handler/internal/imports/host.go
@@ -179,6 +179,6 @@ func SetStatusCode(statusCode uint32) {
 	setStatusCode(statusCode)
 }
 
-func GetRemoteAddr(ptr uint32, limit BufLimit) (len uint32) {
-	return getRemoteAddr(ptr, limit)
+func GetSourceAddr(ptr uint32, limit BufLimit) (len uint32) {
+	return getSourceAddr(ptr, limit)
 }

--- a/handler/internal/imports/imports.go
+++ b/handler/internal/imports/imports.go
@@ -58,5 +58,5 @@ func getStatusCode() uint32
 //go:wasmimport http_handler set_status_code
 func setStatusCode(statusCode uint32)
 
-//go:wasmimport http_handler get_remote_addr
-func getRemoteAddr(ptr uint32, limit BufLimit) (len uint32)
+//go:wasmimport http_handler get_source_addr
+func getSourceAddr(ptr uint32, limit BufLimit) (len uint32)

--- a/handler/internal/imports/imports.go
+++ b/handler/internal/imports/imports.go
@@ -57,3 +57,6 @@ func getStatusCode() uint32
 
 //go:wasmimport http_handler set_status_code
 func setStatusCode(statusCode uint32)
+
+//go:wasmimport http_handler get_remote_addr
+func getRemoteAddr(ptr uint32, limit BufLimit) (len uint32)

--- a/handler/internal/imports/imports_stub.go
+++ b/handler/internal/imports/imports_stub.go
@@ -78,7 +78,7 @@ func getStatusCode() uint32 {
 // setStatusCode is stubbed for compilation outside TinyGo.
 func setStatusCode(statusCode uint32) {}
 
-// getRemoteAddr is stubbed for compilation outside TinyGo.
-func getRemoteAddr(ptr uint32, limit BufLimit) (len uint32) {
+// getSourceAddr is stubbed for compilation outside TinyGo.
+func getSourceAddr(ptr uint32, limit BufLimit) (len uint32) {
 	return 0
 }

--- a/handler/internal/imports/imports_stub.go
+++ b/handler/internal/imports/imports_stub.go
@@ -77,3 +77,8 @@ func getStatusCode() uint32 {
 
 // setStatusCode is stubbed for compilation outside TinyGo.
 func setStatusCode(statusCode uint32) {}
+
+// getRemoteAddr is stubbed for compilation outside TinyGo.
+func getRemoteAddr(ptr uint32, limit BufLimit) (len uint32) {
+	return 0
+}

--- a/handler/request.go
+++ b/handler/request.go
@@ -57,3 +57,8 @@ func (wasmRequest) Body() api.Body {
 func (wasmRequest) Trailers() api.Header {
 	return wasmRequestTrailers
 }
+
+// GetRemoteAddr implements the same method as documented on api.Request.
+func (wasmRequest) GetRemoteAddr() string {
+	return mem.GetString(imports.GetRemoteAddr)
+}

--- a/handler/request.go
+++ b/handler/request.go
@@ -58,7 +58,7 @@ func (wasmRequest) Trailers() api.Header {
 	return wasmRequestTrailers
 }
 
-// GetRemoteAddr implements the same method as documented on api.Request.
-func (wasmRequest) GetRemoteAddr() string {
-	return mem.GetString(imports.GetRemoteAddr)
+// GetSourceAddr implements the same method as documented on api.Request.
+func (wasmRequest) GetSourceAddr() string {
+	return mem.GetString(imports.GetSourceAddr)
 }


### PR DESCRIPTION
supports both ipv4 and ipv6.

The format is `[::1]:51608` or `127.0.0.1:51701`, so it will map golang net/http RemoteAddr field.